### PR TITLE
Preserve new employee input

### DIFF
--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -117,11 +117,7 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
   useEffect(() => {
     if (!selectedEmployee) {
       setPreviousSubmission(null);
-      // Don't reset the entire submission - preserve any entered data
-      setCurrentSubmission(prev => ({
-        ...prev,
-        employee: { ...prev.employee, name: "", phone: "" }
-      }));
+      // Preserve user-entered values when no employee is selected
       return;
     }
 
@@ -153,8 +149,9 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
           ...prev,
           employee: {
             ...prev.employee,
-            name: prev.employee.name || selectedEmployee.name,
-            phone: prev.employee.phone || selectedEmployee.phone,
+            // Always switch to the newly selected employee's identity
+            name: selectedEmployee.name,
+            phone: selectedEmployee.phone,
             department: prev.employee.department || prevSub?.employee?.department || "Web",
             role: prev.employee.role?.length ? prev.employee.role : (prevSub?.employee?.role || [])
           }


### PR DESCRIPTION
## Summary
- prevent clearing name and phone when no employee is selected
- always switch to the chosen employee's name and phone when selecting

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a641391d9c83238652f83960623d22