### PR TITLE
Hide Previous button on first step

### DIFF
--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -1756,16 +1756,21 @@ Your progress has been automatically saved, so you won't lose any other informat
       <ProgressIndicator />
       <StepContent />
 
-      <div className="flex justify-between items-center mt-4 sm:mt-6 gap-3">
-        <button
-          onClick={prevStep}
-          disabled={currentStep === 1}
-          className="px-4 sm:px-6 py-2 sm:py-3 text-sm sm:text-base text-gray-600 border border-gray-300 rounded-xl hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors touch-manipulation"
-        >
-          <span className="hidden sm:inline">← Previous</span>
-          <span className="sm:hidden">← Back</span>
-        </button>
-        
+      <div
+        className={`flex items-center mt-4 sm:mt-6 gap-3 ${
+          currentStep > 1 ? 'justify-between' : 'justify-end'
+        }`}
+      >
+        {currentStep > 1 && (
+          <button
+            onClick={prevStep}
+            className="px-4 sm:px-6 py-2 sm:py-3 text-sm sm:text-base text-gray-600 border border-gray-300 rounded-xl hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors touch-manipulation"
+          >
+            <span className="hidden sm:inline">← Previous</span>
+            <span className="sm:hidden">← Back</span>
+          </button>
+        )}
+
         <div className="flex items-center gap-3">
           {hasUnsavedChanges && (
             <button


### PR DESCRIPTION
## Summary
- Render "Previous" navigation button only on steps beyond the first
- Adjust navigation layout to keep "Next" button aligned when "Previous" is hidden

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a6414321a08323b38a1bd571da4c5a