### PR TITLE
feat: centralize field validation

### DIFF
--- a/src/components/ui.jsx
+++ b/src/components/ui.jsx
@@ -146,7 +146,7 @@ export function TinyLinks({ items, onAdd, onRemove }) {
   );
 }
 
-export function MultiSelect({ options = [], selected = [], onChange, placeholder = "Select options", disabled = false, error = null }) {
+export function MultiSelect({ options = [], selected = [], onChange, placeholder = "Select options", disabled = false, error = null, onBlur = null }) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = React.useRef(null);
 
@@ -206,8 +206,8 @@ export function MultiSelect({ options = [], selected = [], onChange, placeholder
         className={`w-full border rounded-xl p-3 text-left focus:ring-2 transition-colors ${
           error
             ? 'border-red-300 focus:ring-red-500 focus:border-red-500 bg-red-50'
-            : disabled 
-            ? 'bg-gray-100 text-gray-500 cursor-not-allowed border-gray-300' 
+            : disabled
+            ? 'bg-gray-100 text-gray-500 cursor-not-allowed border-gray-300'
             : 'border-gray-300 hover:border-gray-400 bg-white text-gray-900 focus:ring-blue-500 focus:border-blue-500'
         } ${
           safeSelected.length > 0 ? 'text-gray-900' : 'text-gray-500'
@@ -216,6 +216,7 @@ export function MultiSelect({ options = [], selected = [], onChange, placeholder
         disabled={disabled}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        onBlur={onBlur}
       >
         <div className="flex justify-between items-center">
           <span className="truncate">{displayValue}</span>

--- a/src/components/validation.js
+++ b/src/components/validation.js
@@ -1,5 +1,63 @@
 import { daysInMonth, monthLabel, isDriveUrl, isGensparkUrl } from "./constants";
 
+export function validateField(name, value) {
+  switch (name) {
+    case "employee.phone":
+    case "phone": {
+      const clean = (value || "").replace(/\D/g, "");
+      if (!clean) {
+        return { ok: false, value: "", message: "Phone number is required." };
+      }
+      if (clean.length !== 10) {
+        return {
+          ok: false,
+          value: clean,
+          message: "Phone must be exactly 10 digits and cannot include spaces or letters.",
+        };
+      }
+      return { ok: true, value: clean };
+    }
+    case "employee.name":
+    case "name":
+      if (!value || !String(value).trim()) {
+        return { ok: false, message: "Name is required." };
+      }
+      return { ok: true, value: String(value).trim() };
+    case "employee.department":
+    case "department":
+      if (!value) {
+        return { ok: false, message: "Department is required." };
+      }
+      return { ok: true, value };
+    case "employee.role":
+    case "role":
+      if (!Array.isArray(value) || value.length === 0) {
+        return { ok: false, message: "At least one role is required." };
+      }
+      return { ok: true, value };
+    case "monthKey":
+    case "month": {
+      if (!value) {
+        return { ok: false, message: "Report month is required." };
+      }
+      const monthStr = String(value);
+      if (!/^\d{4}-\d{2}$/.test(monthStr)) {
+        return { ok: false, message: "Invalid month format. Please select a valid month." };
+      }
+      const [year, month] = monthStr.split("-").map(Number);
+      if (month < 1 || month > 12) {
+        return { ok: false, message: "Invalid month value. Please select a month between 1-12." };
+      }
+      if (year < 2020 || year > 2030) {
+        return { ok: false, message: "Invalid year. Please select a year between 2020-2030." };
+      }
+      return { ok: true, value: monthStr };
+    }
+    default:
+      return { ok: true, value };
+  }
+}
+
 export function validateSubmission(model) {
   const errors = [];
   const m = model || {};


### PR DESCRIPTION
## Summary
- add reusable `validateField` helper with phone, name, department, role, and month rules
- wire `EmployeeForm` inputs and final submission to `validateField`
- clean phone input and surface detailed phone error message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a6463401f88323a2c20a7730d0f8a6