### PR TITLE
feat: expand employee feedback categories

### DIFF
--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState, useCallback, useRef } from "react"
 import { useSupabase } from "./SupabaseProvider";
 import { useModal } from "./AppShell";
 import { useFetchSubmissions } from "./useFetchSubmissions";
-import { EMPTY_SUBMISSION, thisMonthKey, prevMonthKey, monthLabel, DEPARTMENTS, ROLES_BY_DEPT } from "./constants";
+import { EMPTY_SUBMISSION, thisMonthKey, prevMonthKey, monthLabel, DEPARTMENTS, ROLES_BY_DEPT, migrateSubmission } from "./constants";
 import { scoreKPIs, scoreLearning, scoreRelationshipFromClients, overallOutOf10, generateSummary } from "./scoring";
 import { CelebrationEffect } from "./CelebrationEffect";
 import { Section, TextField, NumField, TextArea, MultiSelect, ProgressIndicator, StepValidationIndicator } from "./ui";
@@ -221,7 +221,7 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
       const savedData = localStorage.getItem(autoSaveKey);
       
       if (savedData) {
-        const draft = JSON.parse(savedData);
+        const draft = migrateSubmission(JSON.parse(savedData));
         
         // Validate the draft data
         if (!draft.employee && !draft.monthKey) {
@@ -364,9 +364,9 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
   const handleTasksChange = useCallback((value) => updateCurrentSubmission('meta.tasks.count', value), [updateCurrentSubmission]);
   const handleAITableLinkChange = useCallback((value) => updateCurrentSubmission('meta.tasks.aiTableLink', value), [updateCurrentSubmission]);
   const handleAITableScreenshotChange = useCallback((value) => updateCurrentSubmission('meta.tasks.aiTableScreenshot', value), [updateCurrentSubmission]);
-  const handleCompanyFeedbackChange = useCallback((value) => updateCurrentSubmission('feedback.company', value), [updateCurrentSubmission]);
+  const handleTeamFeedbackChange = useCallback((value) => updateCurrentSubmission('feedback.team', value), [updateCurrentSubmission]);
+  const handleManagerFeedbackChange = useCallback((value) => updateCurrentSubmission('feedback.manager', value), [updateCurrentSubmission]);
   const handleHRFeedbackChange = useCallback((value) => updateCurrentSubmission('feedback.hr', value), [updateCurrentSubmission]);
-  const handleChallengesChange = useCallback((value) => updateCurrentSubmission('feedback.challenges', value), [updateCurrentSubmission]);
   const handleAIUsageChange = useCallback((value) => updateCurrentSubmission('aiUsageNotes', value), [updateCurrentSubmission]);
 
   // Use refs to avoid dependency issues in autosave
@@ -1601,26 +1601,26 @@ Your progress has been automatically saved, so you won't lose any other informat
             Share your honest feedback to help improve the work environment.
           </p>
           <div className="space-y-4">
-            <TextArea 
-              label="General feedback about the company" 
-              placeholder="What's working well? What could be improved?"
+            <TextArea
+              label="Team feedback"
+              placeholder="How is your team working together?"
               rows={3}
-              value={currentSubmission.feedback.company}
-              onChange={handleCompanyFeedbackChange}
+              value={currentSubmission.feedback.team}
+              onChange={handleTeamFeedbackChange}
             />
-            <TextArea 
-              label="Feedback regarding HR and policies" 
-              placeholder="Any thoughts on HR processes, communication, or company policies?"
+            <TextArea
+              label="Feedback for your manager/reporting line"
+              placeholder="Any suggestions or concerns for your manager?"
+              rows={3}
+              value={currentSubmission.feedback.manager}
+              onChange={handleManagerFeedbackChange}
+            />
+            <TextArea
+              label="Feedback for HR/policies"
+              placeholder="Thoughts on HR processes or company policies?"
               rows={3}
               value={currentSubmission.feedback.hr}
               onChange={handleHRFeedbackChange}
-            />
-            <TextArea 
-              label="Challenges you are facing" 
-              placeholder="Are there any obstacles or challenges hindering your work or growth?"
-              rows={3}
-              value={currentSubmission.feedback.challenges}
-              onChange={handleChallengesChange}
             />
           </div>
         </div>

--- a/src/components/NewReportDashboard.jsx
+++ b/src/components/NewReportDashboard.jsx
@@ -341,8 +341,9 @@ export function NewReportDashboard({ employeeName, employeePhone, onBack }) {
                 ${submission.feedback ? `
                 <div>
                     <strong>Feedback:</strong>
-                    ${submission.feedback.company ? `<p><em>Company:</em> ${submission.feedback.company}</p>` : ''}
-                    ${submission.feedback.challenges ? `<p><em>Challenges:</em> ${submission.feedback.challenges}</p>` : ''}
+                    ${submission.feedback.team ? `<p><em>Team:</em> ${submission.feedback.team}</p>` : ''}
+                    ${submission.feedback.manager ? `<p><em>Manager:</em> ${submission.feedback.manager}</p>` : ''}
+                    ${submission.feedback.hr ? `<p><em>HR:</em> ${submission.feedback.hr}</p>` : ''}
                 </div>
                 ` : ''}
             </div>

--- a/src/components/PDFDownloadButton.jsx
+++ b/src/components/PDFDownloadButton.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { monthLabel } from './constants';
+import { monthLabel, migrateSubmission } from './constants';
 
 export const PDFDownloadButton = ({ data, employeeName, yearlySummary }) => {
   const generateComprehensiveReport = () => {
-    if (!data || data.length === 0) {
+    const submissions = (data || []).map(migrateSubmission);
+    if (!submissions.length) {
       return `
         <div class="section">
           <h3>No Data Available</h3>
@@ -13,13 +14,13 @@ export const PDFDownloadButton = ({ data, employeeName, yearlySummary }) => {
     }
 
     // Calculate comprehensive statistics
-    const totalLearningHours = data.reduce((sum, d) => {
+    const totalLearningHours = submissions.reduce((sum, d) => {
       return sum + ((d.learning || []).reduce((learningSum, l) => learningSum + (l.durationMins || 0), 0) / 60);
     }, 0);
 
-    const avgOverallScore = data.reduce((sum, d) => sum + (d.scores?.overall || 0), 0) / data.length;
-    const avgKpiScore = data.reduce((sum, d) => sum + (d.scores?.kpiScore || 0), 0) / data.length;
-    const avgLearningScore = data.reduce((sum, d) => sum + (d.scores?.learningScore || 0), 0) / data.length;
+    const avgOverallScore = submissions.reduce((sum, d) => sum + (d.scores?.overall || 0), 0) / submissions.length;
+    const avgKpiScore = submissions.reduce((sum, d) => sum + (d.scores?.kpiScore || 0), 0) / submissions.length;
+    const avgLearningScore = submissions.reduce((sum, d) => sum + (d.scores?.learningScore || 0), 0) / submissions.length;
 
     return `
       <!-- Executive Summary -->
@@ -59,7 +60,7 @@ export const PDFDownloadButton = ({ data, employeeName, yearlySummary }) => {
             <th>Manager Score</th>
             <th>Manager Comments</th>
           </tr>
-          ${data.map(d => {
+          ${submissions.map(d => {
             const learningHours = ((d.learning || []).reduce((sum, l) => sum + (l.durationMins || 0), 0) / 60).toFixed(1);
             return `
               <tr>
@@ -80,7 +81,7 @@ export const PDFDownloadButton = ({ data, employeeName, yearlySummary }) => {
       <!-- Detailed Monthly Breakdown -->
       <div class="section">
         <h3>📋 Monthly Breakdown</h3>
-        ${data.map(d => `
+        ${submissions.map(d => `
           <div class="month-section">
             <h4>${monthLabel(d.monthKey)} Report</h4>
             <div class="month-details">
@@ -130,12 +131,12 @@ export const PDFDownloadButton = ({ data, employeeName, yearlySummary }) => {
               ` : ''}
               
               <!-- Feedback -->
-              ${(d.feedback && (d.feedback.company || d.feedback.hr || d.feedback.challenges)) ? `
+              ${(d.feedback && (d.feedback.team || d.feedback.manager || d.feedback.hr)) ? `
                 <div class="detail-section">
                   <strong>Employee Feedback:</strong>
-                  ${d.feedback.company ? `<p><em>Company:</em> ${d.feedback.company}</p>` : ''}
+                  ${d.feedback.team ? `<p><em>Team:</em> ${d.feedback.team}</p>` : ''}
+                  ${d.feedback.manager ? `<p><em>Manager:</em> ${d.feedback.manager}</p>` : ''}
                   ${d.feedback.hr ? `<p><em>HR:</em> ${d.feedback.hr}</p>` : ''}
-                  ${d.feedback.challenges ? `<p><em>Challenges:</em> ${d.feedback.challenges}</p>` : ''}
                 </div>
               ` : ''}
             </div>

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -74,8 +74,21 @@ export const EMPTY_SUBMISSION = {
   clients: [],
   learning: [],
   aiUsageNotes: "",
-  feedback: { company: "", hr: "", challenges: "" },
+  feedback: { team: "", manager: "", hr: "" },
   flags: { missingLearningHours: false, hasEscalations: false, missingReports: false },
   manager: { verified: false, comments: "", score: 0, hiddenDataFlag: false },
   scores: { kpiScore: 0, learningScore: 0, relationshipScore: 0, overall: 0 },
+};
+
+export const migrateFeedback = (feedback = {}) => {
+  const { team, manager, hr, company, challenges } = feedback || {};
+  return {
+    team: team || company || "",
+    manager: manager || challenges || "",
+    hr: hr || "",
+  };
+};
+
+export const migrateSubmission = (submission = {}) => {
+  return { ...submission, feedback: migrateFeedback(submission.feedback) };
 };

--- a/src/components/useFetchSubmissions.js
+++ b/src/components/useFetchSubmissions.js
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useSupabase } from './SupabaseProvider';
+import { migrateSubmission } from './constants';
 
 export function useFetchSubmissions() {
   const supabase = useSupabase();
@@ -34,7 +35,8 @@ export function useFetchSubmissions() {
         
         if (error) throw error;
 
-        setAllSubmissions(data || []);
+        const migrated = (data || []).map(migrateSubmission);
+        setAllSubmissions(migrated);
         setError(null);
         break; // Success, exit retry loop
         


### PR DESCRIPTION
## Summary
- capture team, manager, and HR feedback separately in employee reports
- migrate legacy submissions and drafts to new feedback keys
- update PDF export and dashboards to show new feedback categories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a6463fdf60832380ebfd79ea4b2bf1