### PR TITLE
Enhance submission summaries with performance deltas

### DIFF
--- a/src/components/EmployeePersonalDashboard.jsx
+++ b/src/components/EmployeePersonalDashboard.jsx
@@ -3,6 +3,7 @@ import { useFetchSubmissions } from "./useFetchSubmissions.js";
 import { useModal } from "./AppShell";
 import { thisMonthKey, monthLabel } from "./constants";
 import { ClientReportsView } from "./ClientReportsView";
+import { generateSummary } from "./scoring";
 
 export function EmployeePersonalDashboard({ employee, onBack }) {
   const { allSubmissions, loading } = useFetchSubmissions();
@@ -74,12 +75,9 @@ export function EmployeePersonalDashboard({ employee, onBack }) {
     a.click();
     URL.revokeObjectURL(url);
   };
-
   const getSubmissionSummary = (submission) => {
-    return `📈 PERFORMANCE SUMMARY - ${monthLabel(submission.monthKey)}\n\n★ Overall Score: ${submission.scores?.overall?.toFixed(1) || 'N/A'}/10\n\n🎯 KPI Performance: ${submission.scores?.kpiScore?.toFixed(1) || 'N/A'}/10\n🎓 Learning Activities: ${submission.scores?.learningScore?.toFixed(1) || 'N/A'}/10\n🤝 Client Relations: ${submission.scores?.relationshipScore?.toFixed(1) || 'N/A'}/10\n\n${submission.flags?.missingLearningHours ? '⚠️ Action needed: Complete learning hours requirement\n' : ''}
-${submission.flags?.hasEscalations ? '⚠️ Action needed: Address client escalations\n' : ''}
-${submission.flags?.missingReports ? '⚠️ Action needed: Submit missing client reports\n' : ''}
-${submission.manager_remarks ? `\n📝 Manager Feedback:\n${submission.manager_remarks}` : '\n📝 No manager feedback yet'}`;
+    const base = submission.summary || generateSummary(submission);
+    return `${base}${submission.manager_remarks ? `\n📝 Manager Feedback:\n${submission.manager_remarks}` : '\n📝 No manager feedback yet'}`;
   };
 
   if (loading) {

--- a/src/components/EmployeeReportDashboard.jsx
+++ b/src/components/EmployeeReportDashboard.jsx
@@ -34,6 +34,14 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
     return employeeSubmissions.find(s => s.id === selectedReportId) || null;
   }, [employeeSubmissions, selectedReportId]);
 
+  const selectedSummary = useMemo(() => {
+    if (!selectedReport) return "";
+    if (selectedReport.summary) return selectedReport.summary;
+    const index = employeeSubmissions.findIndex(s => s.id === selectedReport.id);
+    const prev = index > 0 ? employeeSubmissions[index - 1] : null;
+    return generateSummary(selectedReport, prev);
+  }, [selectedReport, employeeSubmissions]);
+
   const yearlySummary = useMemo(() => {
     if (!employeeSubmissions.length) {
       return null;
@@ -335,7 +343,7 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
             </div>
             <div className="mt-4">
               <h4 className="font-medium text-gray-700">AI-Generated Summary:</h4>
-              <p className="text-sm text-gray-600 whitespace-pre-wrap">{generateSummary(selectedReport)}</p>
+              <p className="text-sm text-gray-600 whitespace-pre-wrap">{selectedSummary}</p>
             </div>
             <details className="mt-4 cursor-pointer">
               <summary className="font-medium text-blue-600 hover:text-blue-800">

--- a/src/components/ManagerDashboard.jsx
+++ b/src/components/ManagerDashboard.jsx
@@ -736,6 +736,11 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
             </div>
             
             <div className="px-6 py-4 space-y-6">
+              {evaluationPanel.submission?.summary && (
+                <div className="bg-gray-50 p-3 rounded-md text-sm text-gray-700 whitespace-pre-wrap">
+                  {evaluationPanel.submission.summary}
+                </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   Manager Score (1-10)


### PR DESCRIPTION
## Summary
- compute and attach per-submission summary with month-over-month deltas
- display stored summary on employee and manager dashboards
- show manager evaluation panel with current report summary

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64a446c008323818e675678a4d54c