### PR TITLE
feat: add Supabase audit logging and review view

### DIFF
--- a/src/components/AuditLogView.jsx
+++ b/src/components/AuditLogView.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useSupabase } from './SupabaseProvider';
+
+export function AuditLogView() {
+  const supabase = useSupabase();
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    const fetchLogs = async () => {
+      if (!supabase) return;
+      const { data, error } = await supabase
+        .from('audit_log')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .limit(100);
+      if (!error && data) setLogs(data);
+    };
+    fetchLogs();
+  }, [supabase]);
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border p-6">
+      <h2 className="text-xl font-semibold mb-4">Audit Log</h2>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="px-2 py-1">Time</th>
+              <th className="px-2 py-1">User</th>
+              <th className="px-2 py-1">Action</th>
+              <th className="px-2 py-1">Details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {logs.map(log => (
+              <tr key={log.id} className="border-b">
+                <td className="px-2 py-1">{new Date(log.created_at).toLocaleString()}</td>
+                <td className="px-2 py-1">{log.user_id || 'unknown'}</td>
+                <td className="px-2 py-1">{log.action}</td>
+                <td className="px-2 py-1">
+                  <pre className="whitespace-pre-wrap">{JSON.stringify(log.details)}</pre>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ClientManagementView.jsx
+++ b/src/components/ClientManagementView.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useEffect, useState } from "react";
 import { useSupabase } from "./SupabaseProvider";
 import { CLIENT_SERVICES, DELIVERY_FREQUENCIES, createServiceObject, EMPTY_CLIENT } from "./clientServices";
 import { getClientRepository } from "./ClientRepository";
+import { logAuditEvent } from "./audit";
 
 export function ClientManagementView() {
   const supabase = useSupabase();
@@ -81,8 +82,15 @@ export function ClientManagementView() {
       setServiceFrequencies({});
       setShowCreateForm(false);
       fetchClients();
-      
-      console.log('✅ Successfully created client:', result.name);
+
+      logAuditEvent(supabase, {
+        userId: result.created_by || 'system',
+        action: 'create_client',
+        details: {
+          clientId: result.id,
+          clientName: result.name,
+        },
+      });
     } catch (error) {
       console.error('Error creating client:', error);
       alert('Failed to create client. Please try again.');
@@ -120,8 +128,15 @@ export function ClientManagementView() {
       setSelectedServices([]);
       setServiceFrequencies({});
       fetchClients();
-      
-      console.log('✅ Successfully updated client services');
+
+      logAuditEvent(supabase, {
+        userId: 'manager',
+        action: 'update_client_services',
+        details: {
+          clientId: selectedClientForServices.id,
+          servicesCount: services.length,
+        },
+      });
     } catch (error) {
       console.error('Error updating client services:', error);
       alert('Failed to update services. Please try again.');

--- a/src/components/audit.js
+++ b/src/components/audit.js
@@ -1,0 +1,14 @@
+export async function logAuditEvent(supabase, { userId, action, details = {} }) {
+  if (!supabase) return;
+  const entry = {
+    user_id: userId,
+    action,
+    details: { ...details, timestamp: new Date().toISOString() },
+    created_at: new Date().toISOString()
+  };
+  try {
+    await supabase.from('audit_log').insert(entry);
+  } catch (error) {
+    console.error('Failed to log audit event:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add `logAuditEvent` utility to write audit logs to Supabase
- replace console logging with audit events in manager and client flows
- add simple AuditLogView and navigation tab for compliance review

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64bd84e2c832392ce8ae913a38e6f