### PR TITLE
Add employee-client linking and syncing helpers

### DIFF
--- a/src/components/clientServices.js
+++ b/src/components/clientServices.js
@@ -88,3 +88,39 @@ export const mergeClientData = (repositoryClient, formClient) => ({
   // Update timestamp
   updated_at: new Date().toISOString()
 });
+// Link an employee to a client with scope and frequency
+export const linkEmployeeClient = async (supabase, { employee_id, client_id, scope, frequency }) => {
+  if (!supabase) return null;
+  try {
+    const { data, error } = await supabase
+      .from('employee_clients')
+      .upsert({ employee_id, client_id, scope, frequency }, { onConflict: 'employee_id,client_id,scope' })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  } catch (error) {
+    console.error('Error linking employee and client:', error);
+    return null;
+  }
+};
+
+// Fetch clients linked to an employee. If no employee_id provided, returns all links
+export const fetchEmployeeClients = async (supabase, employee_id = null) => {
+  if (!supabase) return [];
+  try {
+    let query = supabase
+      .from('employee_clients')
+      .select('*, clients(*)');
+    if (employee_id) {
+      query = query.eq('employee_id', employee_id);
+    }
+    const { data, error } = await query;
+    if (error) throw error;
+    return data || [];
+  } catch (error) {
+    console.error('Error fetching employee clients:', error);
+    return [];
+  }
+};
+

--- a/supabase/employee_clients.sql
+++ b/supabase/employee_clients.sql
@@ -1,0 +1,8 @@
+create table if not exists employee_clients (
+  employee_id uuid references employees(id) on delete cascade,
+  client_id uuid references clients(id) on delete cascade,
+  scope text,
+  frequency text,
+  inserted_at timestamptz default now(),
+  primary key (employee_id, client_id, scope)
+);


### PR DESCRIPTION
## Summary
- define `employee_clients` join table for employee-client scope and frequency
- add Supabase helpers to link employees and clients
- sync client data through new helpers in repository, hooks, and dashboards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a64bd98f74832380c538c1092d6cfe