### PR TITLE
feat: add client satisfaction tracking

### DIFF
--- a/src/components/EmployeeReportDashboard.jsx
+++ b/src/components/EmployeeReportDashboard.jsx
@@ -43,6 +43,7 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
     let totalLearning = 0;
     let totalRelationship = 0;
     let totalOverall = 0;
+    let totalClientSatisfaction = 0;
     let monthsWithLearningShortfall = 0;
 
     employeeSubmissions.forEach(s => {
@@ -50,6 +51,7 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
       totalLearning += s.scores?.learningScore || 0;
       totalRelationship += s.scores?.relationshipScore || 0;
       totalOverall += s.scores?.overall || 0;
+      totalClientSatisfaction += s.manager?.clientSatisfaction || 0;
       if ((s.learning || []).reduce((sum, e) => sum + (e.durationMins || 0), 0) < 360) {
         monthsWithLearningShortfall++;
       }
@@ -60,12 +62,14 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
     const avgLearning = round1(totalLearning / totalMonths);
     const avgRelationship = round1(totalRelationship / totalMonths);
     const avgOverall = round1(totalOverall / totalMonths);
+    const avgClientSatisfaction = round1(totalClientSatisfaction / totalMonths);
 
     return {
       avgKpi,
       avgLearning,
       avgRelationship,
       avgOverall,
+      avgClientSatisfaction,
       totalMonths,
       monthsWithLearningShortfall
     };
@@ -157,6 +161,7 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
 ### Employee Performance Report for ${employeeName}
 -   **Total Months Submitted:** ${yearlySummary.totalMonths}
 -   **Average Overall Score:** ${yearlySummary.avgOverall}/10
+-   **Average Client Satisfaction:** ${yearlySummary.avgClientSatisfaction}/10
 -   **Months with Learning Shortfall:** ${yearlySummary.monthsWithLearningShortfall}
 ---
 
@@ -170,6 +175,8 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
 -   **Client Relationship Score:** ${s.scores.relationshipScore}/10
 -   **Manager Notes:** ${s.manager?.comments || 'N/A'}
 -   **Manager Score:** ${s.manager?.score || 'N/A'}
+-   **Client Satisfaction:** ${s.manager?.clientSatisfaction || 'N/A'}/10
+-   **Review Notes:** ${s.manager?.reviewNotes || 'N/A'}
 ---
 `;
     });
@@ -241,7 +248,7 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
 
       {yearlySummary && (
         <Section title="Cumulative Summary & Recommendations">
-          <div className="grid md:grid-cols-4 gap-4 text-center mb-6">
+          <div className="grid md:grid-cols-5 gap-4 text-center mb-6">
             <div className="bg-blue-600 text-white rounded-2xl p-4">
               <div className="text-sm opacity-80">Average Overall</div>
               <div className="text-3xl font-semibold">{yearlySummary.avgOverall}/10</div>
@@ -253,6 +260,10 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
             <div className="bg-white border rounded-2xl p-4 shadow-sm">
               <div className="text-sm opacity-80">Average Learning</div>
               <div className="font-bold text-3xl">{yearlySummary.avgLearning}/10</div>
+            </div>
+            <div className="bg-white border rounded-2xl p-4 shadow-sm">
+              <div className="text-sm opacity-80">Avg Client Sat.</div>
+              <div className="text-3xl font-semibold">{yearlySummary.avgClientSatisfaction}/10</div>
             </div>
             <div className="bg-white border rounded-2xl p-4 shadow-sm">
               <div className="text-sm opacity-80">Learning Shortfall</div>
@@ -271,6 +282,18 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
                   score: s.scores?.overall || 0
                 }))}
                 title="📈 Performance Trend Over Time"
+              />
+            </div>
+          )}
+
+          {employeeSubmissions.some(s => s.manager?.clientSatisfaction) && (
+            <div className="mb-6">
+              <PerformanceChart
+                data={employeeSubmissions.map(s => ({
+                  month: monthLabel(s.monthKey),
+                  score: s.manager?.clientSatisfaction || 0
+                }))}
+                title="😊 Client Satisfaction Trend"
               />
             </div>
           )}

--- a/src/components/ManagerDashboard.jsx
+++ b/src/components/ManagerDashboard.jsx
@@ -27,7 +27,9 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
     submission: null,
     score: 8,
     comments: '',
-    recommendations: ''
+    recommendations: '',
+    clientSatisfaction: 8,
+    reviewNotes: ''
   });
 
   const processedData = useMemo(() => {
@@ -132,12 +134,27 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
       submission,
       score: submission.manager?.score || 8,
       comments: submission.manager?.comments || '',
-      recommendations: submission.manager?.recommendations || ''
+      recommendations: submission.manager?.recommendations || '',
+      clientSatisfaction: submission.manager?.clientSatisfaction || 8,
+      reviewNotes: submission.manager?.reviewNotes || ''
     });
   };
 
   const saveEvaluation = async () => {
     if (!evaluationPanel.submission || !supabase) return;
+
+    if (
+      evaluationPanel.clientSatisfaction < 1 ||
+      evaluationPanel.clientSatisfaction > 10 ||
+      !evaluationPanel.reviewNotes.trim()
+    ) {
+      openModal(
+        'Missing Feedback',
+        'Please provide a client satisfaction score between 1-10 and review notes.',
+        closeModal
+      );
+      return;
+    }
 
     try {
       const updatedSubmission = {
@@ -146,6 +163,8 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
           score: evaluationPanel.score,
           comments: evaluationPanel.comments,
           recommendations: evaluationPanel.recommendations,
+          clientSatisfaction: evaluationPanel.clientSatisfaction,
+          reviewNotes: evaluationPanel.reviewNotes,
           evaluatedAt: new Date().toISOString(),
           evaluatedBy: 'Manager'
         }
@@ -159,7 +178,15 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
       if (error) throw error;
 
       await refreshSubmissions();
-      setEvaluationPanel({ isOpen: false, submission: null, score: 8, comments: '', recommendations: '' });
+      setEvaluationPanel({
+        isOpen: false,
+        submission: null,
+        score: 8,
+        comments: '',
+        recommendations: '',
+        clientSatisfaction: 8,
+        reviewNotes: ''
+      });
       openModal('Success', 'Employee evaluation saved successfully!', closeModal);
     } catch (error) {
       console.error('Failed to save evaluation:', error);
@@ -755,6 +782,23 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Client Satisfaction (1-10)
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  max="10"
+                  value={evaluationPanel.clientSatisfaction}
+                  onChange={(e) => setEvaluationPanel(prev => ({
+                    ...prev,
+                    clientSatisfaction: parseInt(e.target.value)
+                  }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
                   Comments
                 </label>
                 <textarea
@@ -765,6 +809,22 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                     comments: e.target.value 
                   }))}
                   placeholder="Add your feedback about the employee's performance..."
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Review Notes
+                </label>
+                <textarea
+                  rows={3}
+                  value={evaluationPanel.reviewNotes}
+                  onChange={(e) => setEvaluationPanel(prev => ({
+                    ...prev,
+                    reviewNotes: e.target.value
+                  }))}
+                  placeholder="Summarize the client review call and key points discussed..."
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 />
               </div>


### PR DESCRIPTION
## Summary
- capture client satisfaction scores and review notes in manager evaluations
- require managers to provide feedback and store in submissions
- visualize client satisfaction trends in employee reporting dashboard

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64be32e188323891ee1aa878a6434