### PR TITLE
feat: track deliverables and scope progress

### DIFF
--- a/src/components/ClientRepository.js
+++ b/src/components/ClientRepository.js
@@ -201,7 +201,7 @@ export class ClientRepository {
   }
 
   // Update client services
-  async updateClientServices(clientId, services) {
+  async updateClientServices(clientId, services, service_scopes) {
     if (!this.supabase) return null;
     
     try {
@@ -209,6 +209,7 @@ export class ClientRepository {
         .from('clients')
         .update({
           services,
+          service_scopes,
           updated_at: new Date().toISOString()
         })
         .eq('id', clientId)

--- a/src/components/kpi.jsx
+++ b/src/components/kpi.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { NumField, ProofField, TextArea, MultiSelect, PrevValue, TinyLinks, Section, ComparativeField } from "./ui";
 import { monthLabel, isDriveUrl, isGensparkUrl, uid, round1 } from "./constants";
+import { calculateScopeCompletion } from "./scoring.js";
 import { useModal } from "./AppShell";
 import { useSupabase } from "./SupabaseProvider";
 import { ClientReportStatus } from "./ClientReportStatus";
@@ -272,38 +273,6 @@ function KPIsWebHead({ client, prevClient, onChange }) {
       <ProofField label="Upsell proof / invoice" value={client.web_saasProof} onChange={v => onChange({ ...client, web_saasProof: v })} />
     </div>
   );
-}
-
-function calculateScopeCompletion(client, service) {
-  if (!client.service_scopes || !client.service_scopes[service]) return null;
-  
-  const scope = client.service_scopes[service];
-  const deliverables = scope.deliverables || 0;
-  
-  switch (service) {
-    case 'Social Media':
-      const totalPosts = (client.sm_graphicsPhotoshop || 0) + (client.sm_graphicsCanva || 0) + 
-                        (client.sm_graphicsAi || 0) + (client.sm_shortVideos || 0) + (client.sm_longVideos || 0);
-      return deliverables > 0 ? Math.min(100, Math.round((totalPosts / deliverables) * 100)) : 0;
-    case 'SEO':
-    case 'GBP SEO':
-      const keywordsWorked = client.seo_keywordsWorked ? client.seo_keywordsWorked.length : 0;
-      const top3Keywords = client.seo_top3 ? client.seo_top3.length : 0;
-      const totalSeoWork = keywordsWorked + top3Keywords + (client.seo_technicalIssues || 0);
-      return deliverables > 0 ? Math.min(100, Math.round((totalSeoWork / deliverables) * 100)) : 0;
-    case 'Google Ads':
-    case 'Meta Ads':
-      const adsCreated = client.ads_newAds || 0;
-      return deliverables > 0 ? Math.min(100, Math.round((adsCreated / deliverables) * 100)) : 0;
-    case 'Website Maintenance':
-      const webPages = (client.web_pagesThis || 0);
-      const webTasks = webPages + (client.web_saasUpsells || 0);
-      return deliverables > 0 ? Math.min(100, Math.round((webTasks / deliverables) * 100)) : 0;
-    case 'AI':
-      return 0;
-    default:
-      return 0;
-  }
 }
 
 function KPIsSocial({ client, prevClient, employeeRole, onChange, monthPrev, monthThis, isNewClient }) {


### PR DESCRIPTION
## Summary
- add per-service deliverable and scope fields when creating or editing clients
- show official service deliverables during KPI entry and compute completion automatically
- weight KPI scoring by scoped deliverable counts and frequencies

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64be33cbc8323a9d931e96ee08a0f