### PR TITLE
feat: sync employee form with client repository

### DIFF
--- a/src/components/useClientSync.js
+++ b/src/components/useClientSync.js
@@ -1,84 +1,54 @@
-import { useMemo } from 'react';
-import { useFetchSubmissions } from './useFetchSubmissions';
+import { useEffect, useMemo, useState } from 'react';
+import { useSupabase } from './SupabaseProvider';
+import { getClientRepository } from './ClientRepository';
 
+// Hook to sync client repository data for dropdowns and lookups
 export function useClientSync() {
-  const { allSubmissions, loading, error } = useFetchSubmissions();
+  const supabase = useSupabase();
+  const [allClients, setAllClients] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  // Extract all unique clients from all submissions
-  const allClients = useMemo(() => {
-    if (!allSubmissions || allSubmissions.length === 0) return [];
+  useEffect(() => {
+    if (!supabase) return;
 
-    const clientMap = new Map();
-
-    allSubmissions.forEach(submission => {
-      if (submission.clients && Array.isArray(submission.clients)) {
-        submission.clients.forEach(client => {
-          if (client && client.name && client.name.trim()) {
-            const clientKey = client.name.trim().toLowerCase();
-            
-            // Store the most complete client info we have
-            if (!clientMap.has(clientKey) || 
-                (clientMap.get(clientKey).services || []).length < (client.services || []).length) {
-              clientMap.set(clientKey, {
-                name: client.name.trim(),
-                services: client.services || [],
-                // Add other common client properties here
-                industry: client.industry || '',
-                lastUpdated: submission.monthKey,
-                employeeName: submission.employee?.name,
-                employeePhone: submission.employee?.phone
-              });
-            }
-          }
-        });
+    const fetchClients = async () => {
+      try {
+        setLoading(true);
+        const repo = getClientRepository(supabase);
+        const clients = await repo.getAllClients();
+        setAllClients(clients || []);
+        setError(null);
+      } catch (err) {
+        console.error('Error syncing clients:', err);
+        setError(err);
+        setAllClients([]);
+      } finally {
+        setLoading(false);
       }
-    });
+    };
 
-    // Convert Map to array and sort by name
-    return Array.from(clientMap.values()).sort((a, b) => a.name.localeCompare(b.name));
-  }, [allSubmissions]);
+    fetchClients();
+  }, [supabase]);
 
-  // Get clients for a specific employee
-  const getClientsForEmployee = (employeeName, employeePhone) => {
-    if (!allSubmissions || allSubmissions.length === 0) return [];
-
-    const employeeClients = new Set();
-    
-    allSubmissions.forEach(submission => {
-      if (submission.employee?.name === employeeName && 
-          submission.employee?.phone === employeePhone &&
-          submission.clients) {
-        submission.clients.forEach(client => {
-          if (client && client.name && client.name.trim()) {
-            employeeClients.add(client.name.trim());
-          }
-        });
-      }
-    });
-
-    return Array.from(employeeClients).sort();
-  };
-
-  // Get client names for dropdown options
-  const getClientOptions = () => {
-    return allClients.map(client => ({
+  const getClientOptions = useMemo(() => {
+    return (allClients || []).map(client => ({
       value: client.name,
       label: client.name,
+      team: client.team,
       services: client.services,
-      lastUpdated: client.lastUpdated
+      status: client.status
     }));
-  };
+  }, [allClients]);
 
-  // Check if a client exists in the system
   const clientExists = (clientName) => {
     if (!clientName || !clientName.trim()) return false;
-    const normalizedName = clientName.trim().toLowerCase();
-    return allClients.some(client => client.name.toLowerCase() === normalizedName);
+    const normalized = clientName.trim().toLowerCase();
+    return allClients.some(c => c.name.toLowerCase() === normalized);
   };
 
   return {
     allClients,
-    getClientsForEmployee,
     getClientOptions,
     clientExists,
     loading,


### PR DESCRIPTION
## Summary
- load client options with `useClientSync` hook backed by client repository
- allow employees to request new clients, storing provisional entries for manager approval
- persist only approved clients when submitting reports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a64be4180c8323aeb855d7c80e1824