### PR TITLE
Add structured performance summary with improvement tips

### DIFF
--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -640,93 +640,27 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
     });
   }, [kpiScore, learningScore, relationshipScore, overall, flags]);
 
-  const generatePerformanceFeedback = (submission) => {
-    const scores = submission.scores || {};
-    const feedback = {
-      overall: scores.overall || 0,
-      strengths: [],
-      improvements: [],
-      nextMonthGoals: [],
-      summary: ''
-    };
-
-    if (scores.kpiScore >= 8) {
-      feedback.strengths.push('Excellent KPI performance - exceeding departmental targets');
-    } else if (scores.kpiScore >= 6) {
-      feedback.strengths.push('Good KPI performance - meeting most targets');
-      feedback.improvements.push('Focus on key metrics that are slightly below target');
-    } else {
-      feedback.improvements.push('KPI performance needs improvement - review departmental goals and strategies');
-      feedback.nextMonthGoals.push('Develop action plan to improve key performance indicators');
-    }
-
-    const learningHours = (submission.learning || []).reduce((s, e) => s + (e.durationMins || 0), 0) / 60;
-    if (scores.learningScore >= 8) {
-      feedback.strengths.push(`Outstanding commitment to learning with ${learningHours.toFixed(1)} hours completed`);
-    } else if (scores.learningScore >= 6) {
-      feedback.strengths.push('Good learning progress this month');
-    } else {
-      feedback.improvements.push('Increase learning activities to meet minimum 6-hour requirement');
-      feedback.nextMonthGoals.push('Schedule dedicated learning time throughout the month');
-    }
-
-    if (scores.relationshipScore >= 8) {
-      feedback.strengths.push('Excellent client relationship management and communication');
-    } else if (scores.relationshipScore >= 6) {
-      feedback.improvements.push('Continue strengthening client relationships and communication');
-    } else {
-      feedback.improvements.push('Client relationship management needs significant improvement');
-      feedback.nextMonthGoals.push('Develop better client communication strategies and follow-up systems');
-    }
-
-    if (submission.flags?.missingLearningHours) {
-      feedback.improvements.push('Complete the required 6 hours of learning activities');
-      feedback.nextMonthGoals.push('Plan learning schedule at the beginning of each month');
-    }
-
-    if (submission.flags?.hasEscalations) {
-      feedback.improvements.push('Address client escalations and improve proactive communication');
-      feedback.nextMonthGoals.push('Implement client satisfaction monitoring and regular check-ins');
-    }
-
-    if (submission.flags?.missingReports) {
-      feedback.improvements.push('Ensure all client reports are completed and delivered on time');
-      feedback.nextMonthGoals.push('Set up report delivery tracking and deadline reminders');
-    }
-
-    if (feedback.overall >= 8) {
-      feedback.summary = 'Exceptional performance this month! You\'re exceeding expectations and making significant contributions to the team.';
-    } else if (feedback.overall >= 6) {
-      feedback.summary = 'Good solid performance with room for growth. Focus on the improvement areas to reach the next level.';
-    } else {
-      feedback.summary = 'Performance needs improvement. Please work closely with your manager to address the identified areas.';
-    }
-
-    return feedback;
-  };
-
-  const showPerformanceFeedbackModal = (feedback, submission) => {
+  const showSummaryModal = (summary, submission) => {
     const modalContent = `
-📊 PERFORMANCE REPORT - ${submission.monthKey.replace('-', ' ').toUpperCase()}
+📊 PERFORMANCE SUMMARY - ${submission.monthKey.replace('-', ' ').toUpperCase()}
 
-🎯 Overall Score: ${feedback.overall.toFixed(1)}/10
-
-${feedback.summary}
+${summary.overview}
 
 ✅ STRENGTHS:
-${feedback.strengths.map(s => `• ${s}`).join('\n') || '• None identified this month'}
+${summary.strengths.map(s => `• ${s}`).join('\n') || '• None'}
 
-🔧 AREAS FOR IMPROVEMENT:
-${feedback.improvements.map(i => `• ${i}`).join('\n') || '• Keep up the excellent work!'}
+⚠️ WEAKNESSES:
+${summary.weaknesses.map(w => `• ${w}`).join('\n') || '• None'}
 
-🎯 NEXT MONTH'S GOALS:
-${feedback.nextMonthGoals.map(g => `• ${g}`).join('\n') || '• Continue current performance level'}
+🚫 MISSED TASKS:
+${summary.missed.map(m => `• ${m}`).join('\n') || '• None'}
 
-💡 Remember: Consistent improvement leads to long-term success!
+💡 NEXT MONTH TIPS:
+${summary.tips.map(t => `• ${t}`).join('\n') || '• Keep up the good work'}
     `;
 
     openModal(
-      'Performance Feedback Report',
+      'Performance Summary',
       modalContent,
       closeModal,
       null,
@@ -877,8 +811,8 @@ Your progress has been automatically saved, so you won't lose any other informat
         console.error('Failed to remove backup:', e);
       }
       
-      const performanceFeedback = generatePerformanceFeedback(final);
-      showPerformanceFeedbackModal(performanceFeedback, final);
+      const summary = generateSummary(final);
+      showSummaryModal(summary, final);
       
       clearDraft(); // Clear draft only on success
       setCurrentSubmission({ ...EMPTY_SUBMISSION, monthKey: prevMonthKey(thisMonthKey()) });

--- a/src/components/EmployeeReportDashboard.jsx
+++ b/src/components/EmployeeReportDashboard.jsx
@@ -34,6 +34,10 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
     return employeeSubmissions.find(s => s.id === selectedReportId) || null;
   }, [employeeSubmissions, selectedReportId]);
 
+  const reportSummary = useMemo(() => {
+    return selectedReport ? generateSummary(selectedReport) : null;
+  }, [selectedReport]);
+
   const yearlySummary = useMemo(() => {
     if (!employeeSubmissions.length) {
       return null;
@@ -333,10 +337,48 @@ export function EmployeeReportDashboard({ employeeName, employeePhone, onBack })
                 <div className="font-bold text-xl">{(selectedReport.learning || []).reduce((sum, e) => sum + (e.durationMins || 0), 0) / 60}h</div>
               </div>
             </div>
-            <div className="mt-4">
-              <h4 className="font-medium text-gray-700">AI-Generated Summary:</h4>
-              <p className="text-sm text-gray-600 whitespace-pre-wrap">{generateSummary(selectedReport)}</p>
-            </div>
+            {reportSummary && (
+              <div className="mt-4 space-y-2">
+                <h4 className="font-medium text-gray-700">AI-Generated Summary:</h4>
+                <p className="text-sm text-gray-600 whitespace-pre-wrap">{reportSummary.overview}</p>
+                <div className="grid sm:grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <h5 className="font-medium text-green-700">Strengths</h5>
+                    <ul className="list-disc pl-5">
+                      {reportSummary.strengths.length
+                        ? reportSummary.strengths.map((s, i) => <li key={i}>{s}</li>)
+                        : <li>None</li>}
+                    </ul>
+                  </div>
+                  <div>
+                    <h5 className="font-medium text-red-700">Weaknesses</h5>
+                    <ul className="list-disc pl-5">
+                      {reportSummary.weaknesses.length
+                        ? reportSummary.weaknesses.map((w, i) => <li key={i}>{w}</li>)
+                        : <li>None</li>}
+                    </ul>
+                  </div>
+                </div>
+                <div className="grid sm:grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <h5 className="font-medium text-yellow-700">Missed Tasks</h5>
+                    <ul className="list-disc pl-5">
+                      {reportSummary.missed.length
+                        ? reportSummary.missed.map((m, i) => <li key={i}>{m}</li>)
+                        : <li>None</li>}
+                    </ul>
+                  </div>
+                  <div>
+                    <h5 className="font-medium text-blue-700">Next Month Tips</h5>
+                    <ul className="list-disc pl-5">
+                      {reportSummary.tips.length
+                        ? reportSummary.tips.map((t, i) => <li key={i}>{t}</li>)
+                        : <li>Keep up the good work</li>}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            )}
             <details className="mt-4 cursor-pointer">
               <summary className="font-medium text-blue-600 hover:text-blue-800">
                 View Full Submission Data


### PR DESCRIPTION
## Summary
- expand `generateSummary` to classify strengths, weaknesses, missed tasks and next month tips based on scores and flags
- display structured summary in submission modal and employee dashboard
- provide actionable tips for areas needing improvement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64c85bc288323ba488ad32ec69dca