### PR TITLE
feat: display employee testimonials

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -231,7 +231,8 @@ export function AppContent() {
             currentUser: {
               name: employeeSubmissions[0].employee.name,
               phone: employeeSubmissions[0].employee.phone,
-              department: employeeSubmissions[0].employee.department
+              department: employeeSubmissions[0].employee.department,
+              testimonials: employeeSubmissions[0].employee.testimonials || []
             },
             loginError: ''
           });

--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -139,11 +139,12 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
       if (isFormEmpty) {
         return {
           ...EMPTY_SUBMISSION,
-          employee: { 
-            name: selectedEmployee.name, 
-            phone: selectedEmployee.phone, 
-            department: prevSub?.employee?.department || "Web", 
-            role: prevSub?.employee?.role || [] 
+          employee: {
+            name: selectedEmployee.name,
+            phone: selectedEmployee.phone,
+            department: prevSub?.employee?.department || "Web",
+            role: prevSub?.employee?.role || [],
+            testimonials: prevSub?.employee?.testimonials || []
           },
           monthKey: prevMonthKey(thisMonthKey()),
         };
@@ -156,7 +157,8 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
             name: prev.employee.name || selectedEmployee.name,
             phone: prev.employee.phone || selectedEmployee.phone,
             department: prev.employee.department || prevSub?.employee?.department || "Web",
-            role: prev.employee.role?.length ? prev.employee.role : (prevSub?.employee?.role || [])
+            role: prev.employee.role?.length ? prev.employee.role : (prevSub?.employee?.role || []),
+            testimonials: prev.employee.testimonials?.length ? prev.employee.testimonials : (prevSub?.employee?.testimonials || [])
           }
         };
       }

--- a/src/components/EmployeePersonalDashboard.jsx
+++ b/src/components/EmployeePersonalDashboard.jsx
@@ -102,7 +102,23 @@ ${submission.manager_remarks ? `\n📝 Manager Feedback:\n${submission.manager_r
               {employee.name.charAt(0).toUpperCase()}
             </div>
             <div className="min-w-0 flex-1">
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 truncate">{employee.name}</h1>
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 flex items-center gap-1 flex-wrap">
+                <span className="truncate">{employee.name}</span>
+                {employee.testimonials?.map((t, idx) => (
+                  <a
+                    key={idx}
+                    href={t.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="relative group"
+                  >
+                    <span className="text-yellow-500 ml-1">🏅</span>
+                    <span className="absolute left-1/2 -translate-x-1/2 mt-1 hidden group-hover:block bg-gray-900 text-white text-xs rounded px-2 py-1 whitespace-nowrap">
+                      {t.client}
+                    </span>
+                  </a>
+                ))}
+              </h1>
               <p className="text-sm sm:text-base text-gray-600">{employee.department} Department</p>
               <p className="text-xs sm:text-sm text-gray-500">Phone: {employee.phone}</p>
             </div>

--- a/src/components/ManagerDashboard.jsx
+++ b/src/components/ManagerDashboard.jsx
@@ -45,6 +45,7 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
           name: submission.employee?.name || 'Unknown',
           phone: submission.employee?.phone || 'N/A',
           department: submission.employee?.department || 'Unknown',
+          testimonials: submission.employee?.testimonials || [],
           submissions: [],
           latestSubmission: null,
           averageScore: 0,

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -69,7 +69,7 @@ export const ADMIN_TOKEN = import.meta.env.VITE_ADMIN_ACCESS_TOKEN || "admin";
 export const EMPTY_SUBMISSION = {
   monthKey: prevMonthKey(thisMonthKey()), // Default to previous month for reporting
   isDraft: true,
-  employee: { name: "", department: "Web", role: [], phone: "" },
+  employee: { name: "", department: "Web", role: [], phone: "", testimonials: [] },
   meta: { attendance: { wfo: 0, wfh: 0 }, tasks: { count: 0, aiTableLink: "", aiTableScreenshot: "" } },
   clients: [],
   learning: [],


### PR DESCRIPTION
## Summary
- add `testimonials` array to employee profiles
- propagate testimonials through login, form and manager dashboards
- show testimonial badges on employee dashboard with hover info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a64c86a89c83238399e75826ad8cf2