### PR TITLE
feat: display employee testimonial badges

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -10,6 +10,7 @@ import { ManagerEditEmployee } from "./ManagerEditEmployee";
 import { EmployeePersonalDashboard } from "./EmployeePersonalDashboard";
 import { HeaderBrand } from "./HeaderBrand";
 import { useFetchSubmissions } from "./useFetchSubmissions";
+import { getEmployeeProfile } from "./employeeProfiles";
 
 function useHash() {
   const initial = typeof window === 'undefined' ? '' : (window.location.hash || '');
@@ -225,13 +226,18 @@ export function AppContent() {
         const hasCompletedSubmission = employeeSubmissions.some(s => !s.isDraft);
 
         if (employeeSubmissions.length > 0 && hasCompletedSubmission) {
+          const profile = getEmployeeProfile(
+            employeeSubmissions[0].employee.name,
+            employeeSubmissions[0].employee.phone
+          );
           setAuthState({
             isLoggedIn: true,
             userType: 'employee',
             currentUser: {
               name: employeeSubmissions[0].employee.name,
               phone: employeeSubmissions[0].employee.phone,
-              department: employeeSubmissions[0].employee.department
+              department: employeeSubmissions[0].employee.department,
+              testimonials: profile?.testimonials || []
             },
             loginError: ''
           });

--- a/src/components/EmployeeForm.jsx
+++ b/src/components/EmployeeForm.jsx
@@ -139,11 +139,12 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
       if (isFormEmpty) {
         return {
           ...EMPTY_SUBMISSION,
-          employee: { 
-            name: selectedEmployee.name, 
-            phone: selectedEmployee.phone, 
-            department: prevSub?.employee?.department || "Web", 
-            role: prevSub?.employee?.role || [] 
+          employee: {
+            name: selectedEmployee.name,
+            phone: selectedEmployee.phone,
+            department: prevSub?.employee?.department || "Web",
+            role: prevSub?.employee?.role || [],
+            testimonials: prevSub?.employee?.testimonials || []
           },
           monthKey: prevMonthKey(thisMonthKey()),
         };
@@ -156,7 +157,8 @@ export function EmployeeForm({ currentUser = null, isManagerEdit = false, onBack
             name: prev.employee.name || selectedEmployee.name,
             phone: prev.employee.phone || selectedEmployee.phone,
             department: prev.employee.department || prevSub?.employee?.department || "Web",
-            role: prev.employee.role?.length ? prev.employee.role : (prevSub?.employee?.role || [])
+            role: prev.employee.role?.length ? prev.employee.role : (prevSub?.employee?.role || []),
+            testimonials: prev.employee.testimonials || prevSub?.employee?.testimonials || []
           }
         };
       }

--- a/src/components/EmployeePersonalDashboard.jsx
+++ b/src/components/EmployeePersonalDashboard.jsx
@@ -102,7 +102,24 @@ ${submission.manager_remarks ? `\n📝 Manager Feedback:\n${submission.manager_r
               {employee.name.charAt(0).toUpperCase()}
             </div>
             <div className="min-w-0 flex-1">
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 truncate">{employee.name}</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 truncate">{employee.name}</h1>
+                {employee.testimonials && employee.testimonials.map((t, i) => (
+                  <div key={i} className="relative group">
+                    <span className="cursor-pointer" role="img" aria-label="testimonial badge">🎖️</span>
+                    <div className="absolute left-1/2 -translate-x-1/2 top-full mt-1 hidden group-hover:block bg-white border border-gray-200 rounded-md shadow-lg p-2 text-xs z-10">
+                      <a
+                        href={t.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline whitespace-nowrap"
+                      >
+                        {t.client}
+                      </a>
+                    </div>
+                  </div>
+                ))}
+              </div>
               <p className="text-sm sm:text-base text-gray-600">{employee.department} Department</p>
               <p className="text-xs sm:text-sm text-gray-500">Phone: {employee.phone}</p>
             </div>

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -69,7 +69,7 @@ export const ADMIN_TOKEN = import.meta.env.VITE_ADMIN_ACCESS_TOKEN || "admin";
 export const EMPTY_SUBMISSION = {
   monthKey: prevMonthKey(thisMonthKey()), // Default to previous month for reporting
   isDraft: true,
-  employee: { name: "", department: "Web", role: [], phone: "" },
+  employee: { name: "", department: "Web", role: [], phone: "", testimonials: [] },
   meta: { attendance: { wfo: 0, wfh: 0 }, tasks: { count: 0, aiTableLink: "", aiTableScreenshot: "" } },
   clients: [],
   learning: [],

--- a/src/components/employeeProfiles.js
+++ b/src/components/employeeProfiles.js
@@ -1,0 +1,34 @@
+export const EMPLOYEE_PROFILES = [
+  {
+    name: "Alice Smith",
+    phone: "1111111111",
+    department: "Web",
+    testimonials: [
+      {
+        client: "Acme Corp",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+      }
+    ]
+  },
+  {
+    name: "Bob Johnson",
+    phone: "2222222222",
+    department: "SEO",
+    testimonials: [
+      {
+        client: "Beta LLC",
+        url: "https://www.youtube.com/watch?v=oHg5SJYRHA0"
+      },
+      {
+        client: "Gamma Inc",
+        url: "https://www.youtube.com/watch?v=DLzxrzFCyOs"
+      }
+    ]
+  }
+];
+
+export function getEmployeeProfile(name, phone) {
+  return EMPLOYEE_PROFILES.find(
+    (e) => e.name === name && e.phone === phone
+  );
+}


### PR DESCRIPTION
## Summary
- add testimonials array to employee profiles
- show testimonial badge icons with hover link on personal dashboard
- load testimonials when employees log in

## Testing
- `npm test` *(fails: missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a64ca1e2908323addad43418a623d1