### PR TITLE
chore: remove unused toast hook

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -11,7 +11,7 @@ import { EmployeePersonalDashboard } from "./EmployeePersonalDashboard";
 import { HeaderBrand } from "@/shared/components/HeaderBrand";
 import { useFetchSubmissions } from "./useFetchSubmissions";
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary";
-import { ToastProvider, useToast } from "@/shared/components/Toast";
+import { ToastProvider } from "@/shared/components/Toast";
 
 function useHash() {
   const initial = typeof window === 'undefined' ? '' : (window.location.hash || '');


### PR DESCRIPTION
## Summary
- remove useToast import from AppShell

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7395397908323b53ecfd2ec594a14