### PR TITLE
refactor: replace scoring requires with imports

### DIFF
--- a/src/components/ManagerDashboard.jsx
+++ b/src/components/ManagerDashboard.jsx
@@ -7,7 +7,7 @@ import { useDataSync } from "./DataSyncContext";
 import { ClientManagementView } from "@/features/clients/components/ClientManagementView";
 import { ClientDashboardView } from "@/features/clients/components/ClientDashboardView";
 import { FixedLeaderboardView } from "./FixedLeaderboardView";
-import { calculateScopeCompletion } from "@/shared/lib/scoring";
+import { calculateScopeCompletion, getServiceWeight } from "@/shared/lib/scoring";
 
 export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport }) {
   const supabase = useSupabase();
@@ -968,7 +968,7 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                                         {c.services.map((s, si) => {
                                           const name = typeof s === 'string' ? s : s.service;
                               const pct = calculateScopeCompletion(c, name, { monthKey: employee.latestSubmission.monthKey }) || 0;
-                              const w = require('@/shared/lib/scoring').getServiceWeight(name);
+                              const w = getServiceWeight(name);
                               return (
                                 <div key={si} className="text-xs">
                                   <div className="flex justify-between mb-0.5"><span className="font-medium">{name} <span className="text-gray-500">(w {w})</span></span><span>{pct}%</span></div>
@@ -1023,7 +1023,6 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                   sub.clients.forEach(c => {
                     (c.services||[]).forEach(s => {
                       const name = typeof s === 'string' ? s : s.service;
-                      const { calculateScopeCompletion } = require('@/shared/lib/scoring');
                       const pct = calculateScopeCompletion(c, name, { monthKey: sub.monthKey }) || 0;
                       if (pct < 60 && (underService==='All' || name===underService)) {
                         entries.push({ employee: emp.name, client: c.name, service: name, pct });
@@ -1101,7 +1100,6 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                 if (!prevClient) return;
                 (c.services||[]).forEach(s => {
                   const name = typeof s === 'string' ? s : s.service;
-                  const { calculateScopeCompletion } = require('@/shared/lib/scoring');
                   const nowPct = calculateScopeCompletion(c, name, { monthKey: latest.monthKey }) || 0;
                   const prevPct = calculateScopeCompletion(prevClient, name, { monthKey: prev.monthKey }) || 0;
                   const delta = nowPct - prevPct;
@@ -1160,7 +1158,6 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                 let deltas = [];
                 (c.services||[]).forEach(s => {
                   const name = typeof s === 'string' ? s : s.service;
-                  const { calculateScopeCompletion } = require('@/shared/lib/scoring');
                   const nowPct = calculateScopeCompletion(c, name, { monthKey: latest.monthKey }) || 0;
                   const prevPct = calculateScopeCompletion(prevClient, name, { monthKey: prev.monthKey }) || 0;
                   deltas.push(nowPct - prevPct);
@@ -1270,8 +1267,6 @@ export function ManagerDashboard({ onViewReport, onEditEmployee, onEditReport })
                           <div className="space-y-2">
                             {c.services.map((s, si) => {
                               const name = typeof s === 'string' ? s : s.service;
-                              // defer require to avoid circular import at top-level
-                              const { calculateScopeCompletion } = require('@/shared/lib/scoring');
                               const pct = calculateScopeCompletion(c, name, { monthKey: evaluationPanel.submission.monthKey }) || 0;
                               return (
                                 <div key={si} className="text-xs">

--- a/src/features/clients/components/ClientDashboardView.jsx
+++ b/src/features/clients/components/ClientDashboardView.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useEffect, useState } from "react";
 import { useSupabase } from "@/components/SupabaseProvider";
 import { useFetchSubmissions } from "@/components/useFetchSubmissions.js";
 import { MultiSelect } from "@/shared/components/ui";
-import { calculateScopeCompletion } from "@/shared/lib/scoring";
+import { calculateScopeCompletion, getServiceWeight } from "@/shared/lib/scoring";
 
 export function ClientDashboardView() {
   const supabase = useSupabase();
@@ -144,14 +144,14 @@ export function ClientDashboardView() {
                   const total = services.reduce((acc, s) => {
                     const nm = typeof s === 'string' ? s : s.service;
                     const p = calculateScopeCompletion(selectedClientData.client, nm, { monthKey: selectedClientData.latestMonthKey }) || 0;
-                    const ww = require('@/shared/lib/scoring').getServiceWeight(nm);
+                    const ww = getServiceWeight(nm);
                     return acc + (ww * p);
                   }, 0) || 1;
                   return services.map((s, idx) => {
                     const name = typeof s === 'string' ? s : s.service;
                     const comp = calculateScopeCompletion(selectedClientData.client, name, { monthKey: selectedClientData.latestMonthKey });
                     const pct = comp == null ? 0 : Math.max(0, Math.min(100, comp));
-                    const w = require('@/shared/lib/scoring').getServiceWeight(name);
+                    const w = getServiceWeight(name);
                     const share = Math.round(((w * pct) / total) * 100);
                     return (
                       <div key={idx} className="text-sm">

--- a/src/features/clients/components/ClientReportsView.jsx
+++ b/src/features/clients/components/ClientReportsView.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect, useState } from "react";
-import { calculateScopeCompletion } from "@/shared/lib/scoring";
+import { calculateScopeCompletion, getServiceWeight } from "@/shared/lib/scoring";
 import { useSupabase } from "@/components/SupabaseProvider";
 
 export function ClientReportsView({ employee, employeeSubmissions }) {
@@ -143,12 +143,12 @@ export function ClientReportsView({ employee, employeeSubmissions }) {
                     {services.map((s, idx) => {
                       const name = typeof s === 'string' ? s : s.service;
                       const pct = calculateScopeCompletion(latestClient, name, { monthKey: latest?.monthKey }) || 0;
-                      const w = require('@/shared/lib/scoring').getServiceWeight(name);
+                      const w = getServiceWeight(name);
                       // compute contribution share across services
                       const total = services.reduce((acc, sv) => {
                         const nm = typeof sv === 'string' ? sv : sv.service;
                         const p = calculateScopeCompletion(latestClient, nm, { monthKey: latest?.monthKey }) || 0;
-                        const ww = require('@/shared/lib/scoring').getServiceWeight(nm);
+                        const ww = getServiceWeight(nm);
                         return acc + (ww * p);
                       }, 0) || 1;
                       const share = Math.round(((w * pct) / total) * 100);


### PR DESCRIPTION
## Summary
- import getServiceWeight in manager and client dashboard components
- replace require-based scoring lookups with direct function imports
- remove remaining `require` usages from related files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a739552e108323ae5a10999809a479