### PR TITLE
chore: remove unused client service imports

### DIFF
--- a/src/features/clients/services/ClientRepository.js
+++ b/src/features/clients/services/ClientRepository.js
@@ -1,6 +1,6 @@
 // Client Repository Service for automatic client management
 
-import { EMPTY_CLIENT, findClientInRepository, mergeClientData, createServiceObject } from '@/shared/services/clientServices';
+import { EMPTY_CLIENT } from '@/shared/services/clientServices';
 
 export class ClientRepository {
   constructor(supabase, dataSyncNotifier = null) {


### PR DESCRIPTION
## Summary
- simplify ClientRepository import to only pull in EMPTY_CLIENT

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a737710bac83238923e1379a72f586