### PR TITLE
Remove unused operationId from DataSyncContext

### DIFF
--- a/src/components/DataSyncContext.jsx
+++ b/src/components/DataSyncContext.jsx
@@ -73,8 +73,6 @@ export const DataSyncProvider = ({ children }) => {
   const fetchSubmissions = useCallback(async (force = false) => {
     if (!supabase) return;
     
-    const operationId = `fetch-submissions-${Date.now()}`;
-    
     // Prevent duplicate operations
     if (!force && pendingOperations.current.has('fetch-submissions')) {
       console.log('📋 Submissions fetch already in progress, skipping...');


### PR DESCRIPTION
## Summary
- remove unused `operationId` variable from `fetchSubmissions`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7376e6ee48323bb0d60de12d6a327