### PR TITLE
refactor: remove unused modal hook import

### DIFF
--- a/src/components/LearningBlock.jsx
+++ b/src/components/LearningBlock.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Section, TextField, NumField, TextArea } from "@/shared/components/ui";
 import { uid } from "@/shared/lib/constants";
-import { useModal } from "./AppShell";
 
 export function LearningBlock({ model, setModel, openModal }) {
   const [draft, setDraft] = useState({ title: '', link: '', durationMins: 0, learned: '', applied: '' });


### PR DESCRIPTION
## Summary
- remove unused useModal import from LearningBlock

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7410a16848323b707230818b9e96f