### PR TITLE
refactor: remove unused useModal import

### DIFF
--- a/src/components/LearningBlock.jsx
+++ b/src/components/LearningBlock.jsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 import { Section, TextField, NumField, TextArea } from "@/shared/components/ui";
 import { uid } from "@/shared/lib/constants";
-import { useModal } from "./AppShell";
-
 export function LearningBlock({ model, setModel, openModal }) {
   const [draft, setDraft] = useState({ title: '', link: '', durationMins: 0, learned: '', applied: '' });
   const total = (model.learning || []).reduce((s, e) => s + (e.durationMins || 0), 0);


### PR DESCRIPTION
## Summary
- remove outdated useModal import in LearningBlock component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a741d68bc0832380bbd46b2698b960