### PR TITLE
chore: remove unused useModal import

### DIFF
--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -24,7 +24,7 @@ function useHash() {
   return hash;
 }
 
-import { ModalContext, useModal } from "@/shared/components/ModalContext";
+import { ModalContext } from "@/shared/components/ModalContext";
 
 
 export function AppContent() {


### PR DESCRIPTION
## Summary
- remove unused `useModal` import from `AppShell`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a741d8799483239dd515f31730f074